### PR TITLE
Fix gke default visibility

### DIFF
--- a/content/usage/extensions/estafette-extensions.md
+++ b/content/usage/extensions/estafette-extensions.md
@@ -234,7 +234,7 @@ production:
   stages:
     deploy:
       image: extensions/gke:stable
-      visibility: public
+      visibility: private
       container:
         repository: estafette
       hosts:


### PR DESCRIPTION
I noticed that the full example shows `private` as the default, and the other one shows `public`.

The `private` is the correct one, right?